### PR TITLE
Improve general performance and fix Heatmap and ColorLegend bugs

### DIFF
--- a/src/charts/Chart.ts
+++ b/src/charts/Chart.ts
@@ -1,5 +1,5 @@
 import { SvgContext } from "../svg/base/SvgContext";
-import { copy, isValuesInObjectKeys, hasValuesWithKeys } from "../utils/functions";
+import { copy, isValuesInObjectKeys, hasValuesWithKeys, filterKeys } from "../utils/functions";
 import { throwError } from "../utils/error";
 import { Subscription } from 'rxjs';
 import { calculateWidth } from "../utils/screen";
@@ -99,22 +99,23 @@ abstract class Chart {
                 this.config.get('propertyY'),
                 this.config.get('propertyZ')
             ],
-            filteredDatum = [];
+            cleanDatum = [],
+            filteredDatum = filterKeys(datum, keys);
 
         if (datumType === Array) {
-            filteredDatum = datum.filter(isValuesInObjectKeys(nullValues, keys));
+            cleanDatum = datum.filter(isValuesInObjectKeys(nullValues, keys));
         } else {
-            if (!hasValuesWithKeys(datum, nullValues, keys)) {
-                filteredDatum.push(datum);
+            if (!hasValuesWithKeys(filteredDatum, nullValues, keys)) {
+                cleanDatum.push(filteredDatum);
             }
         }
 
         switch (streamingStrategy) {
             case StreamingStrategy.ADD:
-                this.data = this.data.concat(filteredDatum);
+                this.data = this.data.concat(cleanDatum);
                 break;
             case StreamingStrategy.REPLACE:
-                this.data = filteredDatum;
+                this.data = cleanDatum;
                 break;
             case StreamingStrategy.NONE:
                 break;
@@ -123,6 +124,7 @@ abstract class Chart {
 
         //Detect excess of elements given a maxNumberOfElements property
         if (numberOfElements > maxNumberOfElements) {
+            console.log('MAXNUMBEROFELEMENTS');
             let position = numberOfElements - maxNumberOfElements;
             this.data = this.data.slice(position);
         }

--- a/src/svg/components/ColorLegend.ts
+++ b/src/svg/components/ColorLegend.ts
@@ -43,7 +43,7 @@ class ColorLegend extends Component {
             return;
         }
 
-        colorScale.domain([0, max(data, (d: any) => d[propertyZ])]);
+        colorScale.domain([min(data, (d: any) => d[propertyZ]), max(data, (d: any) => d[propertyZ])]);
 
         let colorLegend = legendColor()
             .title(legendTitle)

--- a/src/svg/components/TileSet.ts
+++ b/src/svg/components/TileSet.ts
@@ -36,18 +36,18 @@ class TileSet extends Component {
             maxX = max(data, (d) => d[propertyX]),
             maxY = max(data, (d) => d[propertyY]);
 
-        colorScale.domain([0, max(data, (d) => d[propertyZ])]);
+        colorScale.domain([min(data, (d) => d[propertyZ]), max(data, (d) => d[propertyZ])]);
 
         if (xAxisType === 'linear') {
             this.x.updateDomainByMinMax(minX, maxX + xStep);
-            this.x.transition(0);
+            this.x.transition(Globals.COMPONENT_ANIMATION_TIME);
             width = x(xStep) - x(0);
         } else if (xAxisType === 'categorical') {
             width = x.step();
         }
         if (yAxisType === 'linear') {
             this.y.updateDomainByMinMax(minY, maxY + yStep);
-            this.y.transition(0);
+            this.y.transition(Globals.COMPONENT_ANIMATION_TIME);
             heigth = y(0) - y(yStep);
         } else if (yAxisType === 'categorical') {
             heigth = y.step();
@@ -60,6 +60,7 @@ class TileSet extends Component {
         // Update
         tiles.attr('class', 'tile')
             .transition()
+            .duration(Globals.COMPONENT_ANIMATION_TIME)
             .attr('x', (d) => x(d[propertyX]))
             .attr('y', (d) => {
                 if (yAxisType === 'linear') {
@@ -70,10 +71,11 @@ class TileSet extends Component {
             })
             .attr('width', width)
             .attr('height', heigth)
+            .attr('fill-opacity', 1)
             .style('fill', (d) => colorScale(d[propertyZ]));
 
         // Enter
-        tiles
+        let entering = tiles
             .enter().append('rect')
             .attr('class', 'tile')
             .attr('x', (d) => x(d[propertyX]))

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -119,11 +119,19 @@ export function hasValuesWithKeys(obj: any, values: Array<any>, keys: Array<any>
   return false;
 }
 
-
 export function arrayDiff(a: Array<string>, b: Array<string>) {
   return b.filter((i) => a.indexOf(i) < 0);
 };
 
+export function filterKeys(datum: any, keys: any[]) {
+    let anemicDatum: any = {};
+
+    for (let k of keys) {
+        anemicDatum[k] = datum[k];
+    }
+
+    return anemicDatum;
+}
 
 // /** 
 //  * Get the list of visualizations available in Proteic.js


### PR DESCRIPTION
#### What's this PR do?
Improves the performace of streaming visualizations.
Fixes two bugs in Heatmap that caused incorrect visualization of values.
Fixes a bug in ColorLegend that caused the scale to allways start at 0.

#### Where should the reviewer start?
`Chart.keepDrawing` method.

#### How should this be manually tested?
Benchmarking any streaming chart.
Visualize negative values in Heatmap.

#### Any background context you want to provide?
This fix filters all the unused keys in the data object, improving the performance of copy operations and reducing the memory footprint.

The heatmap bug caused the opacity transitions to interrupt, displaying wrong visualization for the values.

#### What are the relevant issues?
#106 

#### Screenshots (if appropriate)
Before:
![pasted image at 2017_04_20 09_22](https://cloud.githubusercontent.com/assets/228243/25220546/6ba5522c-25b2-11e7-898f-ba3ae2312841.png)

After:
![pasted image at 2017_04_20 09_23](https://cloud.githubusercontent.com/assets/228243/25220572/759edb9a-25b2-11e7-94ab-39409bb2f1e8.png)


---
> Thank you! :heart:

:rocket:

