### PR TITLE
Unpivot function

### DIFF
--- a/src/charts/Chart.ts
+++ b/src/charts/Chart.ts
@@ -110,12 +110,12 @@ abstract class Chart {
     }
 
     /**
-     * Pivot wide format data coming from the Datasource to narrow format.
+     * Unpivot wide format data coming from the Datasource to narrow format.
      * 
      * Incoming data may contain mixed narrow and wide formats that will be
      * treated appropriately.
      */
-    public pivot(vars: Array<string>): Chart {
+    public unpivot(vars: Array<string>): Chart {
         this.config.put('pivotVars', vars);
         return this;
     }

--- a/src/charts/Chart.ts
+++ b/src/charts/Chart.ts
@@ -33,6 +33,7 @@ abstract class Chart {
 
         this.data = data;
         this.events = new Map();
+        this.config.put('pivotVars', []);
     }
 
     private _instantiateInjections(Class: { new (...args: any[]): SvgStrategy }) {
@@ -155,7 +156,6 @@ abstract class Chart {
     }
 
     protected keepDrawing(datum: any): void {
-        console.log(datum);
         let streamingStrategy = this.config.get('streamingStrategy'),
             maxNumberOfElements: number = this.config.get('maxNumberOfElements'),
             numberOfElements = this.data.length,

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -53,6 +53,33 @@ export function keys(array: Array<any>, field: string): Set<any> {
   return keys;
 }
 
+/**
+ * Reshapes a datum from wide format to narrow
+ * 
+ * For example:
+ * { id: 1234, name: 'Bob', age: 32, weight: 86 }
+ *    =>
+ * [
+ *    { id: 1234, name: 'Bob', key: age, value: 32 },
+ *    { id: 1234, name: 'Bob', key: weight, value: 86 }
+ * ]
+ * 
+ */
+export function melt(wideDatum: any, vars: Array<string>, id: Array<string>, propertyKey: string, propertyValue: string) {
+    let narrow: any = [];
+
+    vars.forEach((v) => {
+        let obs: any = {};
+        let value = wideDatum[v];
+        obs[propertyKey] = v;
+        obs[propertyValue] = value;
+        id.forEach((id: any) => { obs[id] = wideDatum[id] });
+        narrow.push(obs);
+    });
+
+    return narrow;
+}
+
 
 export function sortBy(array: Array<any>, o: any) {
   let _toString = Object.prototype.toString;


### PR DESCRIPTION
#### What's this PR do?
Adds an function to Chart to unpivot wide format coming from the Datasource to narrow format.
Incoming data may contain mixed narrow and wide formats that will be treated appropriately.

This uses a melt function that reshapes each datum from wide to narrow format, e.g:
```
{ id: 1234, name: 'Bob', age: 32, weight: 86 }
  =>
[
    { id: 1234, name: 'Bob', key: age, value: 32 },
    { id: 1234, name: 'Bob', key: weight, value: 86 }
]
```

#### Where should the reviewer start?
Chart.ts

#### How should this be manually tested?
Try a WebSocket with mixed narrow and wide data.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

---
> Thank you! :heart:

:rocket:

